### PR TITLE
Fix cargo-readme test to pull from main.rs instead of lib.rs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,7 +58,7 @@ jobs:
           profile: minimal
           override: true
       - run: cargo install cargo-readme
-      - run: cargo readme > README.md && git diff --exit-code
+      - run: (cargo readme -i src/main.rs > README.md || cargo readme > README.md) && git diff --exit-code
 
   deny:
     name: cargo deny


### PR DESCRIPTION
Will need to be manually merged, since this fixes a broken test.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>