### PR TITLE
Revert "Update tokio requirement from 0.2 to 0.3"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 reqwest = { version = "0.10.7", features = ["blocking", "json", "native-tls"] }
 rand = "0.7.3"
 
-tokio = { version = "0.3", features = ["macros"] }
+tokio = { version = "0.2", features = ["macros"] }
 warp = { version = "0.2", features = ["tls"] }
 serde = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
Reverts enarx/enarx-keepmgr#5

warp doesn't yet support tokio 0.3 - reverting