### PR TITLE
Fix clippy-related errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # enarx-keepmgr
+
 The Enarx Keep manager binary.
 
 It can be used to create and manage Enarx Keep loaders.
+
+License: Apache-2.0

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#![deny(clippy::all)]
+
 extern crate serde_derive;
 
 use ::host_components::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! The Enarx Keep manager binary.
+//!
+//! It can be used to create and manage Enarx Keep loaders.
+
 #![deny(clippy::all)]
 
 extern crate serde_derive;

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,8 +104,6 @@ mod models {
                                     }
                                     Err(e) => println!("not a useful reply {}", e),
                                 }
-
-                                break;
                             }
                         }
                         Err(_) => println!("Unable to connect to {:?}", path.display()),


### PR DESCRIPTION
This PR fixes 3/4 clippy- or lint-related failures:
- Loop that does not loop
- Missing cargo deny
- Generating README with `cargo readme`

Re: the loop, I think the `break` terminates not just the iteration of the loop, but the entire loop execution, which is why clippy is unhappy. Reference: https://github.com/rust-lang/rust-clippy/issues/257

I cannot fix the 4th failure without removing `warp` as a dependency. It brings in `ring`, which has no license. The dependency chain is: `warp --> tokio-rustls --> rustls --> ring`. (There were a few similar dependency chains, but they all stem from `warp`, `rustls`, and `tokio-rustls`.)

This PR will therefore have to be rebased on top of one that removes `warp` as a dependency. Related: #12 .