### PR TITLE
Update warp and tokio in a single step

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ license = "Apache-2.0"
 reqwest = { version = "0.11.0", features = ["blocking", "json", "native-tls"] }
 rand = "0.8.0"
 
-tokio = { version = "0.2", features = ["macros"] }
-warp = { version = "0.2", features = ["tls"] }
+tokio = { version = "1.0", features = ["macros"] }
+warp = { version = "0.3", features = ["tls"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
Update warp requirement from 0.2 to 0.3

Updates the requirements on [warp](https://github.com/seanmonstar/warp) to permit the latest version.
- [Release notes](https://github.com/seanmonstar/warp/releases)
- [Changelog](https://github.com/seanmonstar/warp/blob/master/CHANGELOG.md)
- [Commits](https://github.com/seanmonstar/warp/compare/v0.2.0...v0.3.0)

Signed-off-by: dependabot[bot] <support@github.com>

Update tokio requirement from 0.2 to 1.0

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
